### PR TITLE
Handle registration closing + waitlist

### DIFF
--- a/_data/retreat2025/details.yml
+++ b/_data/retreat2025/details.yml
@@ -1,5 +1,6 @@
 registration:
   link: "https://forms.gle/4x4o13yndPnZAWxF8"
+  waitlist: null
   pricing_options:
     - date_begin: 2025-01-01
       date_end: 2025-01-31

--- a/_layouts/retreat.html
+++ b/_layouts/retreat.html
@@ -39,6 +39,9 @@ layout: default
             {% else %}
             <a href="{{ details.registration.link }}" target="_blank">Register Here</a>
             {% endif %}
+            {% if details.registration.waitlist != null %}
+            (<a href="{{ details.registration.waitlist }}" target="_blank">Join the Waitlist</a>)
+            {% endif %}
       </li>
     </ul>
 
@@ -149,6 +152,15 @@ layout: default
         >
             {{ btn_text }}
         </a>
+        {% if details.registration.waitlist != null %}
+        <a href="{{ details.registration.waitlist }}"
+            class="btn btn-outline-primary btn-lg"
+            role="button"
+            target="_blank"
+        >
+            Join the Waitlist
+        </a>
+        {% endif %}
     </div>
 
     <div class="alert alert-danger my-4" role="alert">

--- a/_layouts/retreat.html
+++ b/_layouts/retreat.html
@@ -33,7 +33,12 @@ layout: default
       </li>
       <li class="my-2">
         <i class="bi bi-ticket-perforated pe-2"></i>
-        <b>Registration Required:</b> <a href="{{ details.registration.link }}">Register Here</a>
+        <b>Registration Required:</b>
+            {% if details.registration.link == null %}
+            <i>Closed</i>
+            {% else %}
+            <a href="{{ details.registration.link }}" target="_blank">Register Here</a>
+            {% endif %}
       </li>
     </ul>
 
@@ -107,14 +112,14 @@ layout: default
     <ul class="list-group list-group-flush mb-4">
         {% for each in details.registration.pricing_options %}
         <li class="list-group-item">
-            <span class="fw-medium font-monospace pe-4">
+            <span class="fw-medium font-monospace pe-3">
                 ${{ each.cost }} USD
             </span>
             <span class="fst-italic">
                 {{ each.date_begin | date: "%b %-d" }} &mdash; {{ each.date_end | date: "%b %-d" }}
             </span>
             {% if details.registration.pricing_options.first == each %}
-            <span class="text-body-secondary ps-4">
+            <span class="text-body-secondary ps-3">
                 <i class="bi bi-star-fill"></i> Introductory Rate
             </span>
             {% endif %}
@@ -125,9 +130,27 @@ layout: default
             <span class="fw-medium">Registration closes on {{ details.registration.close_date | date: "%B %-d, %Y" }}</span>
         </li>
     </ul>
+
+    {% if details.registration.link == null %}
+        {% assign is_closed = true %}
+        {% assign btn_text = "Registration Closed" %}
+        {% assign disabled = "disabled" %}
+    {% else %}
+        {% assign is_closed = false %}
+        {% assign btn_text = "Register Now" %}
+        {% assign disabled = "" %}
+    {% endif %}
     <div class="d-grid gap-2 col-8 mx-auto my-2">
-        <a href="{{ details.registration.link }}" class="btn btn-primary btn-lg">Register Now</a>
+        <a {% if is_closed == false %} href="{{ details.registration.link }}" {% endif %}
+            class="btn btn-primary btn-lg {{ disabled }}"
+            role="button"
+            aria-disabled="{{ is_closed }}"
+            target="_blank"
+        >
+            {{ btn_text }}
+        </a>
     </div>
+
     <div class="alert alert-danger my-4" role="alert">
         <b>Note:</b> <i>This event is not open to the public.
         Full information and protocols will be provided upon registration.


### PR DESCRIPTION
Now all we have to do is update the yaml to:

```yaml
registration:
  link: null
```

This will:

- disable the button
- update the text to "Registation Closed"

---

Also added a `waitlist:` link, which will render if not `null`.
