### PR TITLE
Update events

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -1,9 +1,9 @@
-- name: Suspension Sunday
-  start_date: 2025-02-09
-  location: Denver, CO
+- start_date: 2025-02-09
+
+- start_date: 2025-03-08
 
 - name: April Retreat
+  page: retreats/2025.md
   start_date: 2025-04-12
   end_date: 2025-04-14
   location: Denver, CO
-  page: retreats/2025.md

--- a/events.md
+++ b/events.md
@@ -4,32 +4,29 @@ title: Events
 ---
 
 <p class="lead">
-We host monthly events in Colorado.
+We host monthly hook suspension events in Colorado.
 Please <a href="{% link contact.md %}">contact us</a> if you're interested in attending.
 </p>
 
-{% assign today_date = 'now' | date: '%Y-%m-%d' %}
-
 <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
-{% for event in site.data.events %}
+{% assign sorted_events = site.data.events | sort: 'start_date' %}
 
-{% assign event_date = event.start_date | date: '%Y-%m-%d' %}
-
-{% if event_date >= today_date %}
+{% for event in sorted_events %}
 <div class="col">
     <div class="card">
         <div class="card-body">
-            <h5 class="card-title">
-                {% if event.page %}
-                <a href="{% link {{ event.page }} %}">{{ event.name }}</a>
+            <h5 class="card-title mb-2">
+                {% if event.name %}
+                    {% if event.page %}
+                        <a href="{% link {{ event.page }} %}">{{ event.name }}</a>
+                    {% else %}
+                        {{ event.name }}
+                    {% endif %}
                 {% else %}
-                {{ event.name }}
+                    Suspension {{ event.start_date | date: "%A" }}
                 {% endif %}
             </h5>
-            <p class="card-text">
-                <i class="bi bi-geo-alt-fill"></i> {{ event.location }}
-            </p>
-            <p class="card-text">
+            <p class="card-text mb-2">
                 <i class="bi bi-calendar-event"></i>
                 {% if event.end_date %}
                     {{ event.start_date | date: "%B %-d" }} &mdash; {{ event.end_date | date: "%B %-d, %Y" }}
@@ -37,15 +34,21 @@ Please <a href="{% link contact.md %}">contact us</a> if you're interested in at
                     {{ event.start_date | date: "%B %-d, %Y" }}
                 {% endif %}
             </p>
+            <p class="card-text">
+                <i class="bi bi-geo-alt-fill"></i>
+                {% if event.location %}
+                    {{ event.location }}
+                {% else %}
+                    Denver, CO
+                {% endif %}
+            </p>
         </div>
     </div>
 </div>
-{% endif %}
-
 {% endfor %}
 </div>
 
 <p class="text-secondary mt-4">
-For a list of global suspension events, please check out 
+For a list of global suspension events, please check out
 <a href="https://calendar.google.com/calendar/embed?src=suspension.events%40gmail.com">this calendar</a>.
 </p>


### PR DESCRIPTION
- Add March monthly meet

- Refactor data/template to remove duplication and avoid repeating the same info everywhere.
    - If no location is specified, default to "Denver, CO"
    - If no name is specified, auto-generate "Suspension Sunday" or "Suspension Saturday" based on the `start_date`

- Sort events by date in Liquid

- Display location below the date (I think this looks better and makes more sense).

- Remove filtering for old events. This didn't seem worth the trouble because it is not dynamic. The page will only update when we push changes -- i.e., after we edit `events.yml`. Since we have to do that, we might as well manually delete old events when doing that.

## Screenshot

![Screenshot 2025-01-13 at 7 22 49 PM](https://github.com/user-attachments/assets/b3ca8c91-53e6-47f6-8aaa-5370bb77b00e)
