### PR TITLE
Add anchors for headings

### DIFF
--- a/_includes/heading_block.html
+++ b/_includes/heading_block.html
@@ -1,4 +1,8 @@
+{% assign title = include.title %}
+{% assign icon = include.icon %}
 
-<h3 class="h3 border-bottom border-secondary-subtle bg-body-tertiary p-2 mt-4 mb-4">
-    {% if include.icon %}<i class="bi {{ include.icon }} pe-2"></i> {% endif %}{{ include.title }}
+<h3 id="{{ title | slugify }}" class="h3 border-bottom border-secondary-subtle bg-body-tertiary p-2 mt-4 mb-4">
+    <a href="#{{ title | slugify }}" class="text-reset text-decoration-none">
+        {% if icon %}<i class="bi {{ icon }} pe-2"></i> {% endif %}{{ title }}
+    </a>
 </h3>


### PR DESCRIPTION
This adds anchor tags for all headings that use `heading_block.html`.

This allows for jumping/linking to specific sections on a page.

For example, the url `denversuspension.com/retreats/2025/#registration-pricing` will load the page and jump directly to the "Registration & Pricing" section.

This is a "nice to have" that I think will be particularly use for all the Resources pages.