### PR TITLE
[Retreat 2025] update speakers list

### DIFF
--- a/_includes/event_speaker_cards.html
+++ b/_includes/event_speaker_cards.html
@@ -1,0 +1,38 @@
+{% assign presenters = event.presentations.presenters %}
+
+{% include heading_block.html title="Presentations" icon="bi-easel" %}
+
+<p>There will be one class or presentation each morning hosted by one of our volunteer speakers.</p>
+<div class="row row-cols-1 row-cols-md-3 g-4 mb-4">
+    {% for each in presenters %}
+    <div class="col">
+        <div class="card">
+            <img src="{{ each.image | img_url: 'presenters' }}" class="card-img-top" alt="{{ each.name }}">
+            <div class="card-body">
+                <h5 class="card-title">{{ each.presentation_title }}</h5>
+                <p class="card-text lead">{{ each.name }}</p>
+                <p class="card-text">{{ each.presentation_description }}</p>
+            </div>
+            <div class="card-footer">
+                <small class="text-body-secondary">{{ each.bio }}</small>
+            </div>
+        </div>
+    </div>
+    {% endfor %}
+    {% if event.presentations.include_tba_card %}
+    <div class="col">
+        <div class="card">
+            <div class="card-img-top bg-secondary-subtle">
+                <h1 class="p-4 m-4 display-1 text-center"><i class="bi bi-person-fill"></i></h1>
+            </div>
+            <div class="card-body">
+                <h5 class="card-title">To Be Announced</h5>
+                <p class="card-text lead">Guest Speaker</p>
+                <p class="card-text">
+                    Speakers and their presentations will be announced as they are confirmed.
+                </p>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+</div>

--- a/_includes/event_speaker_list.html
+++ b/_includes/event_speaker_list.html
@@ -1,0 +1,18 @@
+{% assign presenters = event.presentations.presenters %}
+
+{% include heading_block.html title="Presentations" icon="bi-easel" %}
+
+<p>There will be one class or presentation each morning hosted by one of our volunteer speakers.</p>
+
+<ul class="list-unstyled pt-3">
+    {% for each in presenters %}
+    <li class="list-group-item d-flex justify-content-between align-items-start mb-2">
+        <div>
+            <h5 class="h5">
+               {{ each.presentation_title }}
+            </h5>
+            <p class="fst-italic">{{ each.presentation_description }}</p>
+        </div>
+    </li>
+    {% endfor %}
+</ul>

--- a/_layouts/retreat.html
+++ b/_layouts/retreat.html
@@ -88,41 +88,7 @@ layout: default
     </div>
     {% endfor %}
 
-    {% include heading_block.html title="Presentations" icon="bi-easel" %}
-    <p>There will be one class or presentation each morning hosted by one of our volunteer speakers.</p>
-    <div class="row row-cols-1 row-cols-md-3 g-4 mb-4">
-        {% for each in presenters %}
-        <div class="col">
-            <div class="card">
-                <img src="{{ each.image | img_url: 'presenters' }}" class="card-img-top" alt="{{ each.name }}">
-                <div class="card-body">
-                    <h5 class="card-title">{{ each.presentation_title }}</h5>
-                    <p class="card-text lead">{{ each.name }}</p>
-                    <p class="card-text">{{ each.presentation_description }}</p>
-                </div>
-                <div class="card-footer">
-                    <small class="text-body-secondary">{{ each.bio }}</small>
-                </div>
-            </div>
-        </div>
-        {% endfor %}
-        {% if event.presentations.include_tba_card %}
-        <div class="col">
-            <div class="card">
-                <div class="card-img-top bg-secondary-subtle">
-                    <h1 class="p-4 m-4 display-1 text-center"><i class="bi bi-person-fill"></i></h1>
-                </div>
-                <div class="card-body">
-                    <h5 class="card-title">To Be Announced</h5>
-                    <p class="card-text lead">Guest Speaker</p>
-                    <p class="card-text">
-                        Speakers and their presentations will be announced as they are confirmed.
-                    </p>
-                </div>
-            </div>
-        </div>
-        {% endif %}
-    </div>
+    {% include event_speaker_cards.html event=event %}
 
     {% include heading_block.html title="Venue" icon="bi-building-fill" %}
     <p>{{ details.venue.description }}</p>

--- a/_layouts/retreat.html
+++ b/_layouts/retreat.html
@@ -88,7 +88,7 @@ layout: default
     </div>
     {% endfor %}
 
-    {% include event_speaker_cards.html event=event %}
+    {% include event_speaker_list.html event=event %}
 
     {% include heading_block.html title="Venue" icon="bi-building-fill" %}
     <p>{{ details.venue.description }}</p>


### PR DESCRIPTION
- Extract previous "speaker cards" layout to a new include (this allows us to easily bring back this design in the future, if desired).

- Implement new "speaker list" layout include. Use this for the event.

# Screenshot

![Screenshot 2025-02-13 at 4 23 42 PM](https://github.com/user-attachments/assets/706d2a4a-a39e-4ab9-9521-da0170e5de39)
