### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,16 +7,16 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    labels: []
+    labels: [ ]
 
   - package-ecosystem: bundler
     directory: "/"
     schedule:
       interval: "monthly"
-    labels: []
+    labels: [ ]
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "monthly"
-    labels: []
+    labels: [ ]


### PR DESCRIPTION
This config was supposed to prevent the bot from creating and adding labels, but it did this anyway in #56.

[Based on the docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#labels--), I guess we need a space here? 🤷🏼 