### PR TITLE
Add payments page with venmo link

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -38,3 +38,6 @@ Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate, public
 # ---------
 
 Redirect 301 /sutures/ /resources/general/sutures/
+
+Redirect 301 /payments/ /pay/
+Redirect 301 /venmo/ /pay/

--- a/pay.md
+++ b/pay.md
@@ -1,0 +1,11 @@
+---
+layout: standalone
+title: Payments
+---
+
+<p class="py-2 lead">
+<i class="bi bi-cash-stack pe-1"></i>
+You can send payments via <b>Venmo</b> to <a href="https://account.venmo.com/u/denversuspension">@denversuspension</a>.
+</p>
+
+If you need alternative payment options, please <a href="{% link contact.md %}">contact us</a>.


### PR DESCRIPTION
This page is **not** listed in the navigation menu or anywhere else.

This is just for convenience.

You can now direct people to `/pay` or `/payments` or `/venmo`.

## screenshot

![Screenshot 2025-03-01 at 10 50 34 AM](https://github.com/user-attachments/assets/bd3d1553-1957-4629-a16b-ade88991d8f9)
