### PR TITLE
Update events

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -1,11 +1,9 @@
-- start_date: 2025-02-09
+monthly_meets:
+  - start_date: 2025-05-11
 
-- start_date: 2025-03-08
-
-- name: April Retreat
-  page: retreats/2025.md
-  start_date: 2025-04-12
-  end_date: 2025-04-14
-  location: Denver, CO
-
-- start_date: 2025-05-11
+past_events:
+  - name: April 2025 Retreat
+    page: retreats/2025.md
+    start_date: 2025-04-12
+    end_date: 2025-04-14
+    location: Denver, CO

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -4,9 +4,6 @@
 - title: events
   page: events.md
 
-- title: 2025 retreat
-  page: retreats/2025.md
-
 - title: resources
   page: resources/index.html
   submenu:

--- a/_data/retreat2025/details.yml
+++ b/_data/retreat2025/details.yml
@@ -1,7 +1,7 @@
 banner: retreat2025.png
 registration:
   link: null
-  waitlist: "https://forms.gle/4x4o13yndPnZAWxF8"
+  waitlist: null
   pricing_options:
     - date_begin: 2025-01-01
       date_end: 2025-01-31

--- a/events.md
+++ b/events.md
@@ -9,9 +9,9 @@ Please <a href="{% link contact.md %}">contact us</a> if you're interested in at
 </p>
 
 <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
-{% assign sorted_events = site.data.events | sort: 'start_date' %}
+{% assign sorted_meets = site.data.events.monthly_meets | sort: 'start_date' %}
 
-{% for event in sorted_events %}
+{% for event in sorted_meets %}
 <div class="col">
     <div class="card">
         <div class="card-body">
@@ -50,5 +50,22 @@ Please <a href="{% link contact.md %}">contact us</a> if you're interested in at
 
 <p class="text-secondary mt-4">
 For a list of global suspension events, please check out
-<a href="https://calendar.google.com/calendar/embed?src=suspension.events%40gmail.com">this calendar</a>.
+<a href="https://calendar.google.com/calendar/embed?src=suspension.events%40gmail.com" target="_blank">this calendar</a>.
 </p>
+
+<br/>
+
+<h3 class="h3">Past Events</h3>
+
+<p>
+    In addition to monthly meets, we occasionally host larger events.
+</p>
+
+{% assign past_events = site.data.events.past_events | sort: 'start_date' %}
+<ul>
+{% for event in past_events %}
+<li>
+    <a href="{% link {{ event.page }} %}">{{ event.name }}</a>
+</li>
+{% endfor %}
+</ul>


### PR DESCRIPTION
Various updates to events. This preserves the 2025 Retreat page and info about the event, but it is now only accessible via under "Past Events" on the `/events` page.

- Remove old monthly meets

- Separate `events.yml` into monthly meets and past events

- Move 2025 Retreat to `past_events`

- Remove 2025 Retreat from main menu (page still exists)

- "Close" the 2025 Retreat (aka, remove registration and waitlist links)
